### PR TITLE
Rename plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,43 @@
 
 The Text Trix editor is an open-source, cross-platform text editor whose goal is to make file and text navigation easier for coding and general editing.
 
-Text Trix started out as a homegrown project, originally at https://sourceforge.net/projects/texttrix/ and ported here as of August 2017. A central design philosophy is to simplify text editing without making hidden or unexpected changes to your text.
+Text Trix started out as a homegrown project, originally at [SourceForge](https://sourceforge.net/projects/texttrix/) and ported here as of August 2017. A central design philosophy is to simplify text editing without making hidden or unexpected changes to your text.
 
 ## Features
 
 * Tabbed files and group tabbing
 * Syntax highlighter and spell-checker
-* Develop and install your own plugins
+* Develop and install your own simple plugins
 * Quick find by word or line
 * Line bookmarks for navigating within files
 * Emacs/Vi-style shortcuts available
+* Tab/space/mixed auto-indent
 * Cross-platform and completely free
 
 ## Run
 
 * Binaries of older version (Text Trix 1.0.2) available [here](https://sourceforge.net/projects/texttrix/files/1%29%20Text%20Trix/TextTrix-1.0.2)
-* Launch ``TextTrix.jar``, or use ``TextTrix.exe`` for Windows shortcut
+* Launch ``TextTrix.jar``, or use ``TextTrix.exe`` as a Windows shortcut
 
 ## Compile
 
 ### Dependencies
 
-* Java 1.5+
+* Java 1.5+ (tested mostly on Java 8-10)
 * [JSyntaxPaneTTx](https://github.com/the4thchild/jsyntaxpanettx)
 * [OsterTTx](https://github.com/the4thchild/osterttx)
 
-**Note**: We are in the process of migrating from Sourceforge, including several plugins and a more seamless build process. In the meantime, you can grab the most recent plugin .jar files from [Text Trix 1.0.2](https://sourceforge.net/projects/texttrix/files/1%29%20Text%20Trix/TextTrix-1.0.2/texttrix-1.0.2.zip/download) can copy the `plugins` folders into the git clone root folder.
-
 ### Build
 
+
+
 ```
-# get repos of Text Trix and its dependencies
+# we suggest placing Text Trix and all dependencies in 
+# the same folder
+mkdir ttx
+cd ttx
+
+# clone all repos
 git clone https://github.com/the4thchild/texttrix.git
 git clone https://github.com/the4thchild/jsyntaxpanettx.git
 git clone https://github.com/the4thchild/osterttx.git
@@ -48,6 +54,26 @@ To package the file for portability:
 texttrix/pkg.sh
 ```
 
-## Writing a plugin
+## Plugins
+
+### Get plugins
+
+Plugin repos are collected in the [texttrix](https://github.com/topics/texttrix) topic on GitHub.
+
+To start adding plugins, create a plugins folder in your main folder (alongside `texttrix`) and clone in a plugin repo:
+
+```
+# assumed to be in the folder containing texttrix, osterttx, 
+# and jsyntaxpanettx folders
+mkdir plugins
+cd plugins
+git clone https://github.com/the4thchild/ttx_songsheet.git
+cd ..
+texttrix/build.sh --plug
+```
+
+The resulting plugin JAR will be placed in `texttrix\plugins\ttx_your_plugin.jar`, which will be loaded automatically by Text Trix at runtime.
+
+### Writing a plugin
 
 We're in the process of updating the documentation, but the old one is [here](https://sourceforge.net/p/texttrix/wiki/PlugIn/).

--- a/com/textflex/texttrix/LibTTx.java
+++ b/com/textflex/texttrix/LibTTx.java
@@ -162,17 +162,16 @@ public class LibTTx {
 	
 	private static PlugIn loadPlugIn(String path, String plugInName, ClassLoader loader) {
 		PlugIn plugIn = null;
-		// all plugins are in the package, com.textflex.texttrix
-		String name =
-			"com.textflex.texttrix."
-				+ plugInName.substring(0, plugInName.indexOf(".jar"));
+		// all plugins' main class is com.textflex.texttrix.Plug
+		String name = "com.textflex.texttrix.Plug";
 		try {
 			plugIn = (PlugIn) createObject(name, loader);
 		} catch (Exception e) {
-			System.out.println("The plug-in, " + name + ", could not be"
-				+ NEWLINE + "loaded.  If you'd like to use it, please visit"
-				+ NEWLINE + "http://textflex.com/texttrix/plugins.html to"
-				+ NEWLINE + "contact the plugin maker.");
+			System.out.println(
+				"The plug-in, " + plugInName + ", could not be loaded.  If "
+				+ "\nyou'd like to use it, please visit "
+				+ "\nhttp://textflex.com/texttrix/plugins.html to contact the "
+				+ "\nplugin maker.");
 		}
 		if (plugIn == null) return null;
 		plugIn.setPath(path);

--- a/com/textflex/texttrix/about.txt
+++ b/com/textflex/texttrix/about.txt
@@ -1,6 +1,6 @@
 Text Trix
 the text tinker
-version 1.0.3
+version 1.1.0
 build:
-Copyright (c) 2002, 2017, Text Flex
+Copyright (c) 2002, 2018, Text Flex
 http://textflex.com/texttrix

--- a/pkg.sh
+++ b/pkg.sh
@@ -16,8 +16,8 @@
 #
 # The Initial Developer of the Original Code is
 # Text Flex.
-# Portions created by the Initial Developer are Copyright (C) 2003, 2017
-# the Initial Developer. All Rights Reserved.
+# Portions created by the Initial Developer are Copyright (C) 2003, 2017, 
+# 2018 the Initial Developer. All Rights Reserved.
 #
 # Contributor(s): David Young <david@textflex.com>
 #
@@ -47,13 +47,6 @@ Syntax:
 	pkg.sh [options]
 
 Parameters:
-	--branch=path/to/branch: The branch (or trunk) from which to
-	compile source code.  For example, to compile from the 0.7.1
-	branch, specify \"--branch=branches/0.7.1\".  To compile from the 
-	trunk, 	simply specify \"--branch=trunk\".  The source code release 
-	package	sets the branch to \".\", since the source package does 
-	not contain branches and tags.  Otherwise, defaults to \"trunk\".
-	
 	--help: Lends a hand by displaying yours truly.
 	
 	--java=javac/binary/path: Specifies the path to javac, 
@@ -63,14 +56,6 @@ Parameters:
 	specification.  On Linux, this path defaults to
 	"/usr/java/default/bin", the new link found in Java 6.  
 	
-	--plgbranch=path/to/branch: The plugin branch (or trunk) from which to
-	compile plugin source code.  For example, to compile from the 0.7.1
-	branch, specify \"--plgbranch=branches/0.7.1\".  To compile from the 
-	trunk, 	simply specify \"--plgbranch=trunk\".  The source code release 
-	package	sets the branch to \".\", since the source package does 
-	not contain branches and tags.  Otherwise, defaults to the --branch
-	directory.
-	
 	--prefix=install/location: the directory in which to install Text Trix.
 	Defaults to "/usr/share".
 	
@@ -79,10 +64,10 @@ Parameters:
 	--ver=version: The version number to append to the package names.
 	
 Copyright:
-	Copyright (c) 2003, 2017 Text Flex
+	Copyright (c) 2003, 2018 Text Flex
 
 Last updated:
-	2017-06-07
+	2018-05-12
 "
 
 #####################
@@ -93,7 +78,7 @@ Last updated:
 # version number
 DATE=`date +'%Y-%m-%d-%Hh%M'`
 TIMESTAMP=0
-VER="1.0.3"
+VER="1.1.0"
 
 # the final destination of the resulting packages
 PREFIX=""
@@ -103,15 +88,6 @@ BASE_DIR=""
 
 # compiler location
 JAVA=""
-
-# the chosen plugins; not currently implemented
-PLUGINS="Search ExtraReturnsRemover HTMLReplacer LetterPulse SongSheet"
-
-# SVN texttrix src branch directory
-BRANCH_DIR="trunk"
-
-# SVN plugins src branch directory
-PLUGINS_BRANCH_DIR="$BRANCH_DIR"
 
 LAUNCH4J="launch4j-3.9"
 LAUNCH4J_CONFIG="launch4j-config.xml"
@@ -137,8 +113,6 @@ source "$BASE_DIR"/build-setup.sh
 
 PAR_JAVA="--java"
 PAR_PLUGINS="--plugins"
-PAR_BRANCH_DIR="--branch"
-PAR_PLUGINS_BRANCH_DIR="--plgbranch"
 PAR_PLUG="--plug"
 PAR_API="--api"
 PAR_CHANGELOG="--log"
@@ -176,18 +150,6 @@ then
 			PREFIX="${arg#${PAR_PREFIX}=}"
 			echo "Set to use \"$PREFIX\" as the install path"
 			
-		# texttrix branch dir
-		elif [ ${arg:0:${#PAR_BRANCH_DIR}} = "$PAR_BRANCH_DIR" ]
-		then
-			BRANCH_DIR="${arg#${PAR_BRANCH_DIR}=}"
-			echo "Set to use \"$BRANCH_DIR\" as the texttrix branch dir"
-		
-		# plugins branch dir
-		elif [ ${arg:0:${#PAR_PLUGINS_BRANCH_DIR}} = "$PAR_PLUGINS_BRANCH_DIR" ]
-		then
-			PLUGINS_BRANCH_DIR="${arg#${PAR_PLUGINS_BRANCH_DIR}=}"
-			echo "Set to use \"$PLUGINS_BRANCH_DIR\" as the plugins branch dir"
-			
 		# verion number, which overrides default version
 		elif [ ${arg:0:${#PAR_VER}} = "$PAR_VER" ]
 		then
@@ -220,7 +182,7 @@ BLD_DIR="$WK_DIR/build"
 
 # Sets the texttrix and plugin source directories
 TTX_DIR="$BASE_DIR" # texttrix folder within main dir
-PLGS_DIR="${BASE_DIR%$BRANCH_DIR}/../plugins" # plugins src folder
+PLGS_DIR="${BASE_DIR}/../plugins" # plugins src folder
 DIR="com/textflex/texttrix" # src package structure
 
 ##############################
@@ -285,10 +247,6 @@ cp -rf $PKGDIR $SRCPKGDIR/texttrix # master --> one folder within source package
 
 # add the build files
 cd "$TTX_DIR"
-# remove the branch assignments because no branches in src pkg
-sed 's/BRANCH_DIR=\"trunk\"/BRANCH_DIR=/' plug.sh | \
-		sed 's/PLUGINS_BRANCH_DIR=\"$BRANCH_DIR\"/PLUGINS_BRANCH_DIR=\./' > \
-		"$BLD_DIR/$SRCPKGDIR"/texttrix/plug.sh
 cp -rf pkg.sh run.sh manifest-additions.mf build*.sh README.md \
 		"$BLD_DIR/$SRCPKGDIR"/texttrix
 sed 's/build:/build: '$DATE'/' $DIR/about.txt > \
@@ -299,12 +257,6 @@ sed 's/build:/build: '$DATE'/' $DIR/about.txt > \
 # is currently copied, with only specific files later removed.
 cd "$BLD_DIR"
 cp -rf $PLGS_DIR $SRCPKGDIR
-# move the working branch to the each plugin's root folder, removing all other branches
-for file in `ls $SRCPKGDIR/plugins`
-do
-	mv $SRCPKGDIR/plugins/$file/$PLUGINS_BRANCH_DIR/* $SRCPKGDIR/plugins/$file
-	rm -rf $SRCPKGDIR/plugins/$file/tags $SRCPKGDIR/plugins/$file/branches $SRCPKGDIR/plugins/$file/trunk
-done
 rm $PKGDIR/README.md # remove source-specific files for binary package
 cp "$TTX_DIR"/plugins/*.jar $BLD_DIR/$PKGDIR/plugins # only want jars in binary package
 


### PR DESCRIPTION
Migrate plugins from Subversion and SourceForge to GitHub

- Remove Subversion folder structure and command-line arguments
- Use "classes" output folder for plugins
- Standardize "Plug.java" as main class name for each plugin to simplify plugin loading and allow arbitrary repo names
- Load all plugins in `plugins` folder in main directory