### PR TITLE
Indent from curr line

### DIFF
--- a/com/textflex/texttrix/LibTTx.java
+++ b/com/textflex/texttrix/LibTTx.java
@@ -556,10 +556,7 @@ public class LibTTx {
 	 * @param offset index of first character not included in the search
 	 * @return index of found string; -1 if not found
 	 */
-	public static int reverseIndexOf(
-		String str,
-		String searchStr,
-		int offset) {
+	public static int reverseIndexOf(String str, String searchStr, int offset) {
 		int searchLen = searchStr.length();
 		int strLen = str.length();
 		if (offset > strLen || offset < 0) return -1;


### PR DESCRIPTION
Change multi-line indenting behavior to be more consistent with common practice of starting from the first line in which the cursor is placed. For backward compatibility and to support the alternate practice of selecting text to indent starting with the end of the prior line, do not indent the first line if the very first character is a newline.